### PR TITLE
Show loading widget at bottom of loading lists

### DIFF
--- a/lib/src/widgets/list_view_resource_widget.dart
+++ b/lib/src/widgets/list_view_resource_widget.dart
@@ -247,7 +247,7 @@ class ListViewResourceWidget<T> extends StatelessWidget {
 
     switch (resource.status) {
       case Status.loading:
-        lenght += loadingTileQuantity;
+        lenght += (resource.data ?? []).length + loadingTileQuantity;
         break;
       case Status.success:
         if (emptyWidget != null &&

--- a/lib/src/widgets/list_view_resource_widget.dart
+++ b/lib/src/widgets/list_view_resource_widget.dart
@@ -285,10 +285,10 @@ class ListViewResourceWidget<T> extends StatelessWidget {
     switch (resource.status) {
       case Status.loading:
         if (loadingTile != null) {
-          return loadingTile!;
+          return _handleLoadingState(index, data, loadingTile!);
         }
         if (loadingTileBuilder != null) {
-          return loadingTileBuilder!();
+          return _handleLoadingState(index, data, loadingTileBuilder!());
         }
         break;
       case Status.success:
@@ -314,6 +314,21 @@ class ListViewResourceWidget<T> extends StatelessWidget {
         break;
     }
     return const SizedBox.shrink();
+  }
+
+  Widget _handleLoadingState(int index, List<T> data, Widget returnableLoadingWidget) {
+    final _maxIndexForPopulatedDataArray = data.length - 1;
+    final _shouldReturnEmptyWidget = emptyWidget != null &&
+        (resource.data == null || (resource.data ?? []).isEmpty);
+
+    if (index > _maxIndexForPopulatedDataArray) return returnableLoadingWidget;
+    if (_shouldReturnEmptyWidget) return emptyWidget ?? const SizedBox.shrink();
+    
+    final widget = tileMapper(data[index]);
+    if (separatorBuilder != null) {
+      return separatorBuilder!(index, widget);
+    }
+    return widget;
   }
 
   Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {


### PR DESCRIPTION
## What is the content type?

- Improvement

## Why is this change necessary?

- A list of widgets with some kind of 'infinite scroll + load as you go' is a common pattern we encounter when developing mobile apps. Usually, the user expects some sort of indication that more information is loading at the bottom of said list.

## How does this address the issue?

-  The package already provided a well-thought implementation of a loading widget, which was shown when the resource state was set to `loading`, so we took advantage of that and only treated the case for when the Resource is in the `loading` state, but already has some data from previous data-fetch calls.

- Firstly, we made sure that if the resource has some data, the length of the rendered list takes that into account, the actual implementation is quite simple, and can be viewed in: e1f5820e1e36c60563da966deef16e5c3ed29398
- On the second pass, we made some modifications on the `_generateListBuilder(...Args)`  method, so it can keep rendering the existent data while also showing the loading widget at the bottom.

- The main change to the aforementioned method was the introduction of the `_handleLoadingState(..Args)` which takes upon the role of performing some checks on whether the `_generatedListBuilder` should return a tile with rendered data or the `loadingWidget` itself.  

- The most sensitive task performed by the `_handleLoadingState` method is to ensure that we don't run into a range exception, once now, in the `loading` state we are rendering a list whose length is greater than the one on the `Resource` itself.

- The implementation of this method can be checked at: a4d720440daea6aeff2211cd4bedf994cd73b6f3
